### PR TITLE
New classes for handling stamped PM clouds, Tf, and an interface for filters

### DIFF
--- a/pointmatcher_ros/CMakeLists.txt
+++ b/pointmatcher_ros/CMakeLists.txt
@@ -12,17 +12,22 @@ find_package(catkin REQUIRED COMPONENTS
 )
 
 find_package(libpointmatcher REQUIRED)
+find_package(PCL 1.7 REQUIRED)
+add_definitions(${PCL_DEFINITIONS})
 
 catkin_package(
-  INCLUDE_DIRS include
-  LIBRARIES pointmatcher_ros
+  INCLUDE_DIRS 
+    include
+    ${PCL_INCLUDE_DIRS}
+  LIBRARIES
+    pointmatcher_ros
   CATKIN_DEPENDS
-  roscpp
-  sensor_msgs
-  nav_msgs
-  tf
-  tf_conversions
-  eigen_conversions
+    roscpp
+    sensor_msgs
+    nav_msgs
+    tf
+    tf_conversions
+    eigen_conversions
 )
 
 # c++ 0x
@@ -49,13 +54,20 @@ include_directories(
 add_library(pointmatcher_ros
   src/point_cloud.cpp
   src/transform.cpp
+  src/StampedPointCloud.cpp
+  src/PmTf.cpp
+  src/PointMatcherFilterIface.cpp
+  src/helper_functions.cpp
 )
 include_directories(
   ${catkin_INCLUDE_DIRS}
+  ${PCL_INCLUDE_DIRS}
 )
 target_link_libraries(pointmatcher_ros
   ${catkin_LIBRARIES}
   ${LIBPOINTMATCHER_LIBRARIES}
+  ${PCL_COMMON_LIBRARIES}
+  ${PCL_IO_LIBRARIES}
 )
 
 install(TARGETS pointmatcher_ros

--- a/pointmatcher_ros/include/pointmatcher_ros/Macros.h
+++ b/pointmatcher_ros/include/pointmatcher_ros/Macros.h
@@ -1,0 +1,10 @@
+#pragma once
+
+// std
+#include <string>
+
+// Descriptor names.
+#define PM_ROS_DESC_NAME_NORMALS (std::string("normals"))
+#define PM_ROS_DESC_NAME_CURVATURE (std::string("curvature"))
+#define PM_ROS_DESC_NAME_PROB_STATIC (std::string("probabilityStatic"))
+#define PM_ROS_DESC_NAME_DEBUG (std::string("debug"))

--- a/pointmatcher_ros/include/pointmatcher_ros/PmTf.h
+++ b/pointmatcher_ros/include/pointmatcher_ros/PmTf.h
@@ -1,0 +1,51 @@
+#pragma once
+
+// std
+#include <string>
+
+// ros
+#include <ros/ros.h>
+
+// geometry msgs
+#include <geometry_msgs/TransformStamped.h>
+
+// tf
+#include <tf/tf.h>
+
+// pointmatcher_ros
+#include "pointmatcher_ros/usings.h"
+
+namespace PointMatcher_ros {
+
+class PmTf {
+ public:
+  ros::Time stamp_;
+  std::string sourceFrameId_;
+  std::string targetFrameId_;
+  PmTfParameters parameters_;
+
+ protected:
+  std::shared_ptr<PmTransformator> transformator_;
+
+ public:
+  PmTf();
+
+  static PmTf FromRosTfMsg(const geometry_msgs::TransformStamped& tfMsg);
+  void fromRosTfMsg(const geometry_msgs::TransformStamped& tfMsg);
+  geometry_msgs::TransformStamped toRosTfMsg() const;
+  void toRosTfMsg(geometry_msgs::TransformStamped& tfMsg) const;
+
+  static PmTf FromRosTf(const tf::StampedTransform& tf);
+  void fromRosTf(const tf::StampedTransform& tf);
+  tf::StampedTransform toRosTf() const;
+  void toRosTf(tf::StampedTransform& tf) const;
+
+  PmTf inverse() const;
+
+  float getRotationScaling() const;
+  void fixRotationScaling();
+};
+
+std::ostream& operator<<(std::ostream& ostream, const PmTf& tf);
+
+}  // namespace PointMatcher_ros

--- a/pointmatcher_ros/include/pointmatcher_ros/PointMatcherFilterIface.h
+++ b/pointmatcher_ros/include/pointmatcher_ros/PointMatcherFilterIface.h
@@ -1,0 +1,28 @@
+#pragma once
+
+// ros
+#include <ros/console.h>
+
+// PointMatcher
+#include <pointmatcher/PointMatcher.h>
+
+// pointmatcher_ros
+#include "pointmatcher_ros/point_cloud.h"
+
+namespace PointMatcher_ros {
+
+class PointMatcherFilterIface {
+ public:
+  std::string getDataType() const { return dataType_; }
+  void setDataType(std::string newValue) { dataType_ = newValue; }
+
+  bool readPipelineFile(const std::string& fileName);
+
+  PointMatcher<float>::DataPoints process(const PointMatcher<float>::DataPoints& input);
+
+ private:
+  std::string dataType_;
+  PointMatcher<float>::DataPointsFilters filters_;
+};
+
+}  // namespace PointMatcher_ros

--- a/pointmatcher_ros/include/pointmatcher_ros/StampedPointCloud.h
+++ b/pointmatcher_ros/include/pointmatcher_ros/StampedPointCloud.h
@@ -1,0 +1,78 @@
+#pragma once
+
+// std
+#include <memory>
+
+// std msgs
+#include <std_msgs/Header.h>
+
+// pointmatcher
+#include <pointmatcher_ros/point_cloud.h>
+
+// pcl
+#include <pcl/io/ply_io.h>
+
+// pcl conversions
+#include <pcl_conversions/pcl_conversions.h>
+
+// pointmatcher_ros
+#include "pointmatcher_ros/PmTf.h"
+#include "pointmatcher_ros/usings.h"
+
+namespace PointMatcher_ros {
+
+class StampedPointCloud {
+ public:
+  std_msgs::Header header_;
+  PmDataPoints dataPoints_;
+
+ protected:
+  std::shared_ptr<PmTransformator> transformator_;
+
+ public:
+  StampedPointCloud();
+
+  static StampedPointCloud FromFile(const std::string& filePath, const ros::Time& stamp, const std::string& frameId);
+  bool fromFile(const std::string& filePath, const ros::Time& stamp, const std::string& frameId);
+  void toFile(const std::string& filePath) const;
+
+  static StampedPointCloud FromRosMsg(const sensor_msgs::PointCloud2& msg);
+  void fromRosMsg(const sensor_msgs::PointCloud2& msg);
+  sensor_msgs::PointCloud2 toRosMsg() const;
+  void toRosMsg(sensor_msgs::PointCloud2& msg) const;
+
+  StampedPointCloud createSimilarEmpty() const;
+
+  bool isEmpty() const;
+  unsigned int getSize() const;
+  void clear();
+
+  bool descriptorExists(const std::string& name) const;
+  void addOneDimensionalDescriptor(const std::string& name, const float value);
+  PmDataPointsView getDescriptorView(const std::string& name);
+  PmDataPointsConstView getDescriptorConstView(const std::string& name) const;
+  void setCurvatureFromStaticProbability();
+  void setStaticProbabilityFromCurvature();
+
+  bool transform(const PmTf& tf);
+
+  bool filter(PmPointCloudFilters& filters);
+  void filterByDistance(const float distanceThreshold, const bool keepInside);
+  void filterByDistance(const float distanceThreshold, const bool keepInside, PmMatrix& newIdToOldId);
+  void filterByStaticProbability(const float staticProbabilityThreshold, const bool keepStatic);
+
+  bool add(const StampedPointCloud& other);
+  bool addNonOverlappingPoints(const StampedPointCloud& other, const float maxDistOverlappingPoints);
+
+  bool splitByOverlap(const StampedPointCloud& other, const float distanceThreshold, StampedPointCloud& otherOverlappingPoints,
+                      StampedPointCloud& otherNonOverlappingPoints) const;
+  void splitByStaticProbability(const float staticProbabilityThreshold, StampedPointCloud& staticPoints, StampedPointCloud& dynamicPoints) const;
+
+  unsigned int countStaticPoints(const float staticProbabilityThreshold) const;
+
+  PmMatrix toSphericalCoordinates() const;
+};
+
+std::ostream& operator<<(std::ostream& ostream, const StampedPointCloud& pointCloud);
+
+}  // namespace PointMatcher_ros

--- a/pointmatcher_ros/include/pointmatcher_ros/helper_functions.h
+++ b/pointmatcher_ros/include/pointmatcher_ros/helper_functions.h
@@ -1,0 +1,97 @@
+#pragma once
+
+// ros
+#include <ros/ros.h>
+
+// geometry msgs
+#include <geometry_msgs/PoseStamped.h>
+#include <geometry_msgs/PoseWithCovarianceStamped.h>
+#include <geometry_msgs/TransformStamped.h>
+
+// tf
+#include <tf/tf.h>
+
+// tf conversions
+#include <tf_conversions/tf_eigen.h>
+
+// pointmatcher_ros
+#include "pointmatcher_ros/PmTf.h"
+#include "pointmatcher_ros/usings.h"
+
+namespace PointMatcher_ros {
+
+/*!
+ * Creates a pointmatcher transformation from a ROS transform msg.
+ * @param tfMsg ROS transform msg.
+ * @return Pointmatcher transformation.
+ */
+PmTf tfMsgToPmTf(const geometry_msgs::TransformStamped& tfMsg);
+
+/*!
+ * Creates a ROS transform msg from a pointmatcher transformation.
+ * @param pmTf Pointmatcher transformation.
+ * @return ROS transform msg.
+ */
+geometry_msgs::TransformStamped pmTfToTfMsg(const PmTf& pmTf);
+
+/*!
+ * Creates a pointmatcher transformation from a ROS transformation.
+ * @param tf ROS transformation.
+ * @return Pointmatcher transformation.
+ */
+PmTf tfToPmTf(const tf::StampedTransform& tf);
+
+/*!
+ * Creates a ROS transformation from a pointmatcher transformation.
+ * @param pmTf Pointmatcher transformation.
+ * @return ROS transformation.
+ */
+tf::StampedTransform pmTfToTf(const PmTf& pmTf);
+
+/*!
+ * Creates a pose from a ROS transformation.
+ * @param tf ROS transformation.
+ * @return Pose.
+ */
+geometry_msgs::PoseStamped tfToPose(const tf::StampedTransform& tf);
+
+/*!
+ * Creates a ROS transformation from a pose.
+ * @param pose         Pose.
+ * @param childFrameId Child frame id.
+ * @return ROS transformation.
+ */
+tf::StampedTransform poseToTf(const geometry_msgs::PoseStamped& pose, const std::string& childFrameId);
+
+/*!
+ * Creates a ROS transformation from a pose with covariance.
+ * @param pose         Pose with covariance.
+ * @param childFrameId Child frame id.
+ * @return transformation.
+ */
+tf::StampedTransform poseWithCovToTf(const geometry_msgs::PoseWithCovarianceStamped& pose, const std::string& childFrameId);
+
+/*!
+ * Creates a pointmatcher transformation from a pose with covariance.
+ * @param pose         Pose with covariance.
+ * @param childFrameId Child frame id.
+ * @return Pointmatcher transformation.
+ */
+PmTf poseWithCovToPmTf(const geometry_msgs::PoseWithCovarianceStamped& pose, const std::string& childFrameId);
+
+/*!
+ * Creates a pose from a pointmatcher transformation.
+ * @param pmTf Pointmatcher transformation.
+ * @return Pose.
+ */
+geometry_msgs::PoseStamped pmTfToPose(const PmTf& pmTf);
+
+/*!
+ * Creates a pointmatcher transformation from a pose.
+ * @param pose         Pose.
+ * @param childFrameId Child frame id.
+ * @return Pointmatcher transformation.
+ */
+PmTf poseToPmTf(const geometry_msgs::PoseStamped& pose, const std::string& childFrameId);
+
+}  // namespace PointMatcher_ros

--- a/pointmatcher_ros/include/pointmatcher_ros/usings.h
+++ b/pointmatcher_ros/include/pointmatcher_ros/usings.h
@@ -1,0 +1,27 @@
+#pragma once
+
+// nabo
+#include <nabo/nabo.h>
+
+// pointmatcher
+#include <pointmatcher/PointMatcher.h>
+
+namespace PointMatcher_ros {
+
+// nabo
+using NNS = Nabo::NearestNeighbourSearch<float>;
+using NNSearchType = NNS::SearchType;
+
+// pointmatcher
+using Pm = PointMatcher<float>;
+using PmDataPoints = Pm::DataPoints;
+using PmDataPointsView = PmDataPoints::View;
+using PmDataPointsConstView = PmDataPoints::ConstView;
+using PmIcp = Pm::ICP;
+using PmPointCloudFilters = Pm::DataPointsFilters;
+using PmTransformator = Pm::Transformation;
+using PmTfParameters = Pm::TransformationParameters;
+using PmMatrix = Pm::Matrix;
+using PmMatches = Pm::Matches;
+
+}  // namespace PointMatcher_ros

--- a/pointmatcher_ros/package.xml
+++ b/pointmatcher_ros/package.xml
@@ -20,5 +20,6 @@
   <depend>tf_conversions</depend>
   <depend>eigen_conversions</depend>
   <depend>libpointmatcher-dev</depend>
+  <depend>pcl_conversions</depend>
 
 </package>

--- a/pointmatcher_ros/src/PmTf.cpp
+++ b/pointmatcher_ros/src/PmTf.cpp
@@ -1,0 +1,64 @@
+// pointmatcher_ros
+#include "pointmatcher_ros/PmTf.h"
+#include "pointmatcher_ros/helper_functions.h"
+
+namespace PointMatcher_ros {
+
+PmTf::PmTf() : transformator_(std::shared_ptr<PmTransformator>(Pm::get().REG(Transformation).create("RigidTransformation"))) {
+  parameters_ = Pm::Matrix::Identity(4, 4);
+}
+
+PmTf PmTf::FromRosTfMsg(const geometry_msgs::TransformStamped& tfMsg) {
+  PmTf pmTf;
+  pmTf.fromRosTfMsg(tfMsg);
+  return pmTf;
+}
+
+void PmTf::fromRosTfMsg(const geometry_msgs::TransformStamped& tfMsg) { *this = tfMsgToPmTf(tfMsg); }
+
+geometry_msgs::TransformStamped PmTf::toRosTfMsg() const {
+  geometry_msgs::TransformStamped tfMsg;
+  toRosTfMsg(tfMsg);
+  return tfMsg;
+}
+
+void PmTf::toRosTfMsg(geometry_msgs::TransformStamped& tfMsg) const { tfMsg = pmTfToTfMsg(*this); }
+
+PmTf PmTf::FromRosTf(const tf::StampedTransform& tf) {
+  PmTf pmTf;
+  pmTf.fromRosTf(tf);
+  return pmTf;
+}
+
+void PmTf::fromRosTf(const tf::StampedTransform& tf) { *this = tfToPmTf(tf); }
+
+tf::StampedTransform PmTf::toRosTf() const {
+  tf::StampedTransform tf;
+  toRosTf(tf);
+  return tf;
+}
+
+void PmTf::toRosTf(tf::StampedTransform& tf) const { tf = pmTfToTf(*this); }
+
+PmTf PmTf::inverse() const {
+  PmTf tf;
+  tf.stamp_ = stamp_;
+  tf.sourceFrameId_ = targetFrameId_;
+  tf.targetFrameId_ = sourceFrameId_;
+  tf.parameters_ = parameters_.inverse();
+  return tf;
+}
+
+float PmTf::getRotationScaling() const { return parameters_.topLeftCorner<3, 3>().determinant(); }
+
+void PmTf::fixRotationScaling() { transformator_->correctParameters(parameters_); }
+
+std::ostream& operator<<(std::ostream& ostream, const PmTf& tf) {
+  ostream << "Stamp: " << tf.stamp_ << " ";
+  ostream << "Source frame: " << tf.sourceFrameId_ << " ";
+  ostream << "Target frame: " << tf.targetFrameId_ << std::endl;
+  ostream << "Parameters: " << tf.parameters_ << std::endl;
+  return ostream;
+}
+
+}  // namespace PointMatcher_ros

--- a/pointmatcher_ros/src/PointMatcherFilterIface.cpp
+++ b/pointmatcher_ros/src/PointMatcherFilterIface.cpp
@@ -1,0 +1,33 @@
+
+#include "pointmatcher_ros/PointMatcherFilterIface.h"
+
+#include <exception>
+#include <fstream>
+
+namespace PointMatcher_ros {
+
+bool PointMatcherFilterIface::readPipelineFile(const std::string& fileName) {
+  std::ifstream inFile(fileName.c_str());
+  if (!inFile.good()) {
+    ROS_ERROR_STREAM("PointMatcherFilterIface: Couldn't open pipeline description file from \"" << fileName << "\"");
+    return false;
+  }
+
+  filters_ = PointMatcher<float>::DataPointsFilters(inFile);
+  return true;
+}
+
+PointMatcher<float>::DataPoints PointMatcherFilterIface::process(const PointMatcher<float>::DataPoints& input) {
+  auto localInput = input;
+
+  try {
+    filters_.apply(localInput);
+  } catch (const std::runtime_error& e) {
+    ROS_WARN_STREAM("PointMatcherFilterIface: Caught exception: " << e.what());
+    ROS_WARN_STREAM("PointMatcherFilterIface: Point cloud unchanged");
+  }
+
+  return localInput;
+}
+
+}  // namespace PointMatcher_ros

--- a/pointmatcher_ros/src/StampedPointCloud.cpp
+++ b/pointmatcher_ros/src/StampedPointCloud.cpp
@@ -1,0 +1,326 @@
+// PointMatcher_ros
+#include "pointmatcher_ros/StampedPointCloud.h"
+#include "pointmatcher_ros/Macros.h"
+
+namespace PointMatcher_ros {
+
+StampedPointCloud::StampedPointCloud()
+    : transformator_(std::shared_ptr<PmTransformator>(Pm::get().REG(Transformation).create("RigidTransformation"))) {
+  clear();
+}
+
+StampedPointCloud StampedPointCloud::FromFile(const std::string& filePath, const ros::Time& stamp, const std::string& frameId) {
+  StampedPointCloud pointCloud;
+  pointCloud.fromFile(filePath, stamp, frameId);
+  return pointCloud;
+}
+
+bool StampedPointCloud::fromFile(const std::string& filePath, const ros::Time& stamp, const std::string& frameId) {
+  pcl::PLYReader reader;
+  pcl::PointCloud<pcl::PointXYZINormal> pointCloudPcl;
+  if (reader.read(filePath, pointCloudPcl) < 0) {
+    return false;
+  }
+  pcl_conversions::toPCL(stamp, pointCloudPcl.header.stamp);
+  pointCloudPcl.header.frame_id = frameId;
+
+  // Erase points with NaN as curvature.
+  const unsigned int size = pointCloudPcl.size();
+  for (auto point = pointCloudPcl.end(); point >= pointCloudPcl.begin(); point--) {
+    if (std::isnan(point->curvature)) {
+      ROS_DEBUG_STREAM("IcpTools: Removing point (" << std::distance(pointCloudPcl.begin(), point) << ") with curvature == NaN.");
+      pointCloudPcl.erase(point);
+    }
+  }
+  ROS_INFO_STREAM("IcpTools: Erased " << size - pointCloudPcl.size() << " invalid points from the point cloud.");
+
+  sensor_msgs::PointCloud2 pointCloudRos;
+  pcl::toROSMsg(pointCloudPcl, pointCloudRos);
+  fromRosMsg(pointCloudRos);
+  return true;
+}
+
+void StampedPointCloud::toFile(const std::string& filePath) const {
+  const sensor_msgs::PointCloud2 pointCloudRos = toRosMsg();
+  pcl::PointCloud<pcl::PointXYZINormal> pointCloudPcl;
+  pcl::fromROSMsg(pointCloudRos, pointCloudPcl);
+
+  pcl::PLYWriter writer;
+  writer.write(filePath, pointCloudPcl, false, false);
+}
+
+StampedPointCloud StampedPointCloud::FromRosMsg(const sensor_msgs::PointCloud2& msg) {
+  StampedPointCloud pointCloud;
+  pointCloud.fromRosMsg(msg);
+  return pointCloud;
+}
+
+void StampedPointCloud::fromRosMsg(const sensor_msgs::PointCloud2& msg) {
+  header_ = msg.header;
+  dataPoints_ = PointMatcher_ros::rosMsgToPointMatcherCloud<float>(msg);
+}
+
+sensor_msgs::PointCloud2 StampedPointCloud::toRosMsg() const {
+  sensor_msgs::PointCloud2 msg;
+  toRosMsg(msg);
+  return msg;
+}
+
+void StampedPointCloud::toRosMsg(sensor_msgs::PointCloud2& msg) const {
+  msg = PointMatcher_ros::pointMatcherCloudToRosMsg<float>(dataPoints_, header_.frame_id, header_.stamp);
+}
+
+StampedPointCloud StampedPointCloud::createSimilarEmpty() const {
+  StampedPointCloud similarEmtpy;
+  similarEmtpy.header_ = header_;
+  similarEmtpy.dataPoints_ = dataPoints_.createSimilarEmpty();
+  return similarEmtpy;
+}
+
+bool StampedPointCloud::isEmpty() const { return getSize() == 0; }
+
+unsigned int StampedPointCloud::getSize() const { return dataPoints_.getNbPoints(); }
+
+void StampedPointCloud::clear() {
+  header_ = std_msgs::Header();
+  PmDataPoints::Labels featLabels;
+  featLabels.push_back(PmDataPoints::Label("x", 1));
+  featLabels.push_back(PmDataPoints::Label("y", 1));
+  featLabels.push_back(PmDataPoints::Label("z", 1));
+  featLabels.push_back(PmDataPoints::Label("pad", 1));
+  PmDataPoints::Labels descLabels;
+  const unsigned int pointCount = 0;
+  dataPoints_ = PmDataPoints(featLabels, descLabels, pointCount);
+}
+
+bool StampedPointCloud::descriptorExists(const std::string& name) const { return dataPoints_.descriptorExists(name); }
+
+void StampedPointCloud::addOneDimensionalDescriptor(const std::string& name, const float value) {
+  dataPoints_.addDescriptor(name, PmMatrix::Constant(1, getSize(), value));
+}
+
+PmDataPointsView StampedPointCloud::getDescriptorView(const std::string& name) {
+  // The following line can throw an exception if the descriptor does not exist.
+  return dataPoints_.getDescriptorViewByName(name);
+}
+
+PmDataPointsConstView StampedPointCloud::getDescriptorConstView(const std::string& name) const {
+  // The following line can throw an exception if the descriptor does not exist.
+  return dataPoints_.getDescriptorViewByName(name);
+}
+
+void StampedPointCloud::setCurvatureFromStaticProbability() {
+  dataPoints_.addDescriptor(PM_ROS_DESC_NAME_CURVATURE, dataPoints_.getDescriptorViewByName(PM_ROS_DESC_NAME_PROB_STATIC));
+}
+
+void StampedPointCloud::setStaticProbabilityFromCurvature() {
+  dataPoints_.addDescriptor(PM_ROS_DESC_NAME_PROB_STATIC, dataPoints_.getDescriptorViewByName(PM_ROS_DESC_NAME_CURVATURE));
+}
+
+bool StampedPointCloud::transform(const PmTf& tf) {
+  if (tf.sourceFrameId_ != header_.frame_id) {
+    ROS_ERROR_STREAM("IcpTools: Point cloud transformation failed due to inconsistent frames. "
+                     << "Point cloud frame: '" << header_.frame_id << "', transformation source frame: '" << tf.sourceFrameId_ << "'.");
+    return false;
+  }
+  header_.frame_id = tf.targetFrameId_;
+  try {
+    dataPoints_ = transformator_->compute(dataPoints_, tf.parameters_);
+    return true;
+  } catch (const std::exception& exception) {
+    ROS_ERROR_STREAM("IcpTools: Caught exception while transforming point cloud: " << exception.what());
+    return false;
+  }
+}
+
+bool StampedPointCloud::filter(PmPointCloudFilters& filters) {
+  try {
+    filters.apply(dataPoints_);
+    return true;
+  } catch (const std::exception& exception) {
+    ROS_ERROR_STREAM("IcpTools: Caught exception while filtering point cloud: " << exception.what());
+    return false;
+  }
+}
+
+void StampedPointCloud::filterByDistance(const float distanceThreshold, const bool keepInside) {
+  PmMatrix dummy;
+  filterByDistance(distanceThreshold, keepInside, dummy);
+}
+
+void StampedPointCloud::filterByDistance(const float distanceThreshold, const bool keepInside, PmMatrix& newIdToOldId) {
+  const float distanceThresholdSquared = std::pow(distanceThreshold, 2);
+  newIdToOldId = PmMatrix(1, getSize());
+  unsigned int newId = 0;
+  for (unsigned int oldId = 0; oldId < getSize(); oldId++) {
+    if ((dataPoints_.features.col(oldId).head(3).squaredNorm() <= distanceThresholdSquared) == keepInside) {
+      dataPoints_.setColFrom(newId, dataPoints_, oldId);
+      newIdToOldId(0, newId) = oldId;
+      newId++;
+    }
+  }
+  dataPoints_.conservativeResize(newId);
+  newIdToOldId.conservativeResize(Eigen::NoChange, newId);
+}
+
+void StampedPointCloud::filterByStaticProbability(const float staticProbabilityThreshold, const bool keepStatic) {
+  StampedPointCloud staticPoints;
+  StampedPointCloud dynamicPoints;
+  splitByStaticProbability(staticProbabilityThreshold, staticPoints, dynamicPoints);
+  if (keepStatic) {
+    *this = staticPoints;
+  } else {
+    *this = dynamicPoints;
+  }
+}
+
+bool StampedPointCloud::add(const StampedPointCloud& other) {
+  if (other.header_.frame_id != header_.frame_id) {
+    ROS_ERROR_STREAM("IcpTools: Point cloud concatenation failed due to inconsistent frames. "
+                     << "This frame: '" << header_.frame_id << "', other frame: '" << other.header_.frame_id << "'.");
+    return false;
+  }
+
+  if (other.isEmpty()) {
+    ROS_WARN_STREAM("IcpTools: Point cloud to add is empty, concatenation is not executed.");
+  } else if (dataPoints_.features.rows() != other.dataPoints_.features.rows()) {
+    ROS_INFO_STREAM("IcpTools: Point clouds to concatenate have different features, overwriting them.");
+    dataPoints_ = other.dataPoints_;
+  } else {
+    ROS_DEBUG_STREAM("IcpTools: Concatenating point clouds of sizes " << getSize() << " and " << other.getSize() << " ...");
+    try {
+      dataPoints_.concatenate(other.dataPoints_);
+    } catch (const std::exception& exception) {
+      ROS_ERROR_STREAM("IcpTools: Caught exception while concatenating point clouds: " << exception.what());
+      return false;
+    }
+  }
+  // Update stamp for all of the above cases.
+  header_.stamp = std::max(header_.stamp, other.header_.stamp);
+  return true;
+}
+
+bool StampedPointCloud::addNonOverlappingPoints(const StampedPointCloud& other, const float maxDistOverlappingPoints) {
+  // Split up the other point cloud in overlapping and non-overlapping points.
+  StampedPointCloud otherOverlappingPoints;
+  StampedPointCloud otherNonOverlappingPoints;
+  if (!splitByOverlap(other, maxDistOverlappingPoints, otherOverlappingPoints, otherNonOverlappingPoints)) {
+    ROS_ERROR_STREAM("IcpTools: Overlap could not be found.");
+    return false;
+  }
+
+  // Only add the non-overlapping points.
+  if (!add(otherNonOverlappingPoints)) {
+    ROS_ERROR_STREAM("IcpTools: Non-overlapping points could not be added.");
+    return false;
+  }
+
+  return true;
+}
+
+bool StampedPointCloud::splitByOverlap(const StampedPointCloud& other, const float distanceThreshold, StampedPointCloud& otherOverlappingPoints,
+                                  StampedPointCloud& otherNonOverlappingPoints) const {
+  if (other.header_.frame_id != header_.frame_id) {
+    ROS_ERROR_STREAM("IcpTools: Point cloud finding overlap failed due to inconsistent frames. "
+                     << "This frame: '" << header_.frame_id << "', other frame: '" << other.header_.frame_id << "'.");
+    return false;
+  }
+
+  if (isEmpty()) {
+    // The other point cloud is completely non-overlapping.
+    otherOverlappingPoints = other.createSimilarEmpty();
+    otherNonOverlappingPoints = other;
+  } else {
+    otherOverlappingPoints = other.createSimilarEmpty();
+    otherNonOverlappingPoints = other.createSimilarEmpty();
+
+    // Build and populate NNS.
+    PmMatches matchesOverlap(PmMatches::Dists(1, other.getSize()), PmMatches::Ids(1, other.getSize()));
+    std::shared_ptr<NNS> featureNNS(
+        NNS::create(dataPoints_.features, dataPoints_.features.rows() - 1, NNS::KDTREE_LINEAR_HEAP, NNS::TOUCH_STATISTICS));
+    featureNNS->knn(other.dataPoints_.features, matchesOverlap.ids, matchesOverlap.dists, 1, 0);
+
+    const float distanceThresholdSquared = std::pow(distanceThreshold, 2);
+    unsigned int otherOverlappingPointsSize = 0;
+    unsigned int otherNonOverlappingPointsSize = 0;
+    for (unsigned int i = 0; i < other.getSize(); ++i) {
+      if (matchesOverlap.dists(i) <= distanceThresholdSquared) {
+        // Other point is near, considered as overlapping.
+        otherOverlappingPoints.dataPoints_.setColFrom(otherOverlappingPointsSize, other.dataPoints_, i);
+        otherOverlappingPointsSize++;
+      } else {
+        // Other point is far, considered as non-overlapping.
+        otherNonOverlappingPoints.dataPoints_.setColFrom(otherNonOverlappingPointsSize, other.dataPoints_, i);
+        otherNonOverlappingPointsSize++;
+      }
+    }
+
+    otherOverlappingPoints.dataPoints_.conservativeResize(otherOverlappingPointsSize);
+    otherNonOverlappingPoints.dataPoints_.conservativeResize(otherNonOverlappingPointsSize);
+  }
+
+  return true;
+}
+
+void StampedPointCloud::splitByStaticProbability(const float staticProbabilityThreshold, StampedPointCloud& staticPoints,
+                                            StampedPointCloud& dynamicPoints) const {
+  if (!descriptorExists(PM_ROS_DESC_NAME_PROB_STATIC)) {
+    // This can happen e.g. for empty maps.
+    ROS_DEBUG_STREAM("The point cloud does not contain the static probability descriptor.");
+    // Similar behavior as countStaticPoints(..):
+    staticPoints = *this;
+    dynamicPoints = createSimilarEmpty();
+    return;
+  }
+
+  const PmDataPointsConstView staticProbability = getDescriptorConstView(PM_ROS_DESC_NAME_PROB_STATIC);
+  staticPoints = createSimilarEmpty();
+  dynamicPoints = createSimilarEmpty();
+  unsigned int staticPointsCount = 0;
+  unsigned int dynamicPointsCount = 0;
+  for (unsigned int i = 0; i < getSize(); i++) {
+    if (staticProbability(0, i) >= staticProbabilityThreshold) {
+      staticPoints.dataPoints_.setColFrom(staticPointsCount, dataPoints_, i);
+      staticPointsCount++;
+    } else {
+      dynamicPoints.dataPoints_.setColFrom(dynamicPointsCount, dataPoints_, i);
+      dynamicPointsCount++;
+    }
+  }
+  staticPoints.dataPoints_.conservativeResize(staticPointsCount);
+  dynamicPoints.dataPoints_.conservativeResize(dynamicPointsCount);
+}
+
+unsigned int StampedPointCloud::countStaticPoints(const float staticProbabilityThreshold) const {
+  if (!descriptorExists(PM_ROS_DESC_NAME_PROB_STATIC)) {
+    // This can happen e.g. for empty maps.
+    ROS_DEBUG_STREAM("The point cloud does not contain the static probability descriptor.");
+    // Similar behavior as splitByStaticProbability(..):
+    return getSize();
+  }
+
+  const PmDataPointsConstView staticProbability = getDescriptorConstView(PM_ROS_DESC_NAME_PROB_STATIC);
+  return (staticProbability.array() >= staticProbabilityThreshold).count();
+}
+
+PmMatrix StampedPointCloud::toSphericalCoordinates() const {
+  // 0 = radius, 1 = azimuth, 2 = inclination.
+  PmMatrix sphericalCoordinates = PmMatrix(3, getSize());
+  sphericalCoordinates.row(0) = dataPoints_.features.topRows(3).colwise().norm();
+
+  // Note: Eigen does not support element-wise atan2.
+  for (unsigned int i = 0; i < getSize(); i++) {
+    sphericalCoordinates(1, i) = std::atan2(dataPoints_.features(1, i), dataPoints_.features(0, i));  // atan2(y,x)
+    sphericalCoordinates(2, i) = std::acos(dataPoints_.features(2, i) / sphericalCoordinates(0, i));  // acos(z/r)
+  }
+  return sphericalCoordinates;
+}
+
+std::ostream& operator<<(std::ostream& ostream, const StampedPointCloud& pointCloud) {
+  ostream << "Frame: " << pointCloud.header_.frame_id << " ";
+  ostream << "Stamp: " << pointCloud.header_.stamp.toSec() << " ";
+  ostream << "Size: " << pointCloud.getSize();
+  return ostream;
+}
+
+}  // namespace PointMatcher_ros

--- a/pointmatcher_ros/src/helper_functions.cpp
+++ b/pointmatcher_ros/src/helper_functions.cpp
@@ -1,0 +1,91 @@
+// PointMatcher_ros
+#include "pointmatcher_ros/helper_functions.h"
+
+namespace PointMatcher_ros {
+
+PmTf tfMsgToPmTf(const geometry_msgs::TransformStamped& tfMsg) {
+  tf::StampedTransform tf;
+  tf::transformStampedMsgToTF(tfMsg, tf);
+  return PointMatcher_ros::tfToPmTf(tf);
+}
+
+geometry_msgs::TransformStamped pmTfToTfMsg(const PmTf& pmTf) {
+  geometry_msgs::TransformStamped tfMsg;
+  tf::transformStampedTFToMsg(PointMatcher_ros::pmTfToTf(pmTf), tfMsg);
+  return tfMsg;
+}
+
+PmTf tfToPmTf(const tf::StampedTransform& tf) {
+  PmTf pmTf;
+  pmTf.sourceFrameId_ = tf.child_frame_id_;
+  pmTf.targetFrameId_ = tf.frame_id_;
+  pmTf.stamp_ = tf.stamp_;
+  Eigen::Affine3d affineTf;
+  tf::transformTFToEigen(tf, affineTf);
+  pmTf.parameters_ = affineTf.matrix().cast<float>();
+  return pmTf;
+}
+
+tf::StampedTransform pmTfToTf(const PmTf& pmTf) {
+  tf::StampedTransform tf;
+  tf.child_frame_id_ = pmTf.sourceFrameId_;
+  tf.frame_id_ = pmTf.targetFrameId_;
+  tf.stamp_ = pmTf.stamp_;
+  tf::Matrix3x3 basis(pmTf.parameters_(0, 0), pmTf.parameters_(0, 1), pmTf.parameters_(0, 2), pmTf.parameters_(1, 0),
+                      pmTf.parameters_(1, 1), pmTf.parameters_(1, 2), pmTf.parameters_(2, 0), pmTf.parameters_(2, 1),
+                      pmTf.parameters_(2, 2));
+  tf.setBasis(basis);
+  tf::Vector3 origin(pmTf.parameters_(0, 3), pmTf.parameters_(1, 3), pmTf.parameters_(2, 3));
+  tf.setOrigin(origin);
+  return tf;
+}
+
+geometry_msgs::PoseStamped tfToPose(const tf::StampedTransform& tf) {
+  geometry_msgs::PoseStamped poseStamped;
+  poseStamped.header.frame_id = tf.frame_id_;
+  poseStamped.header.seq = 0;
+  poseStamped.header.stamp = tf.stamp_;
+  poseStamped.pose.position.x = tf.getOrigin().getX();
+  poseStamped.pose.position.y = tf.getOrigin().getY();
+  poseStamped.pose.position.z = tf.getOrigin().getZ();
+  poseStamped.pose.orientation.w = tf.getRotation().getW();
+  poseStamped.pose.orientation.x = tf.getRotation().getX();
+  poseStamped.pose.orientation.y = tf.getRotation().getY();
+  poseStamped.pose.orientation.z = tf.getRotation().getZ();
+  return poseStamped;
+}
+
+tf::StampedTransform poseToTf(const geometry_msgs::PoseStamped& pose, const std::string& childFrameId) {
+  const tf::Vector3 origin(pose.pose.position.x, pose.pose.position.y, pose.pose.position.z);
+  const tf::Quaternion rotation(pose.pose.orientation.x, pose.pose.orientation.y, pose.pose.orientation.z, pose.pose.orientation.w);
+  tf::StampedTransform tf;
+  tf.frame_id_ = pose.header.frame_id;
+  tf.child_frame_id_ = childFrameId;
+  tf.stamp_ = pose.header.stamp;
+  tf.setOrigin(origin);
+  tf.setRotation(rotation);
+  return tf;
+}
+
+tf::StampedTransform poseWithCovToTf(const geometry_msgs::PoseWithCovarianceStamped& pose, const std::string& childFrameId) {
+  const tf::Vector3 origin(pose.pose.pose.position.x, pose.pose.pose.position.y, pose.pose.pose.position.z);
+  const tf::Quaternion rotation(pose.pose.pose.orientation.x, pose.pose.pose.orientation.y, pose.pose.pose.orientation.z,
+                                pose.pose.pose.orientation.w);
+  tf::StampedTransform tf;
+  tf.frame_id_ = pose.header.frame_id;
+  tf.child_frame_id_ = childFrameId;
+  tf.stamp_ = pose.header.stamp;
+  tf.setOrigin(origin);
+  tf.setRotation(rotation);
+  return tf;
+}
+
+PmTf poseWithCovToPmTf(const geometry_msgs::PoseWithCovarianceStamped& pose, const std::string& childFrameId) {
+  return tfToPmTf(poseWithCovToTf(pose, childFrameId));
+}
+
+geometry_msgs::PoseStamped pmTfToPose(const PmTf& pmTf) { return tfToPose(pmTfToTf(pmTf)); }
+
+PmTf poseToPmTf(const geometry_msgs::PoseStamped& pose, const std::string& childFrameId) { return tfToPmTf(poseToTf(pose, childFrameId)); }
+
+}  // namespace PointMatcher_ros


### PR DESCRIPTION
Hi,
In this pull request I have put together some of the classes that we were using in our internal packages for handling PointMatcher clouds *with* timestamps and frame information, coming from ROS. I also added a class, initially developed by Jimmy, for interfacing with PointMatcher filters.

Open questions:
* The style and format of the newest additions is slightly different. For consistency, should I modify the new classes to comply with the original classes that were part of this repo, or should I follow RSL & ANYbotics style guide? The conventions are different.
* Are there other classes / util functions that we should integrate here?
* I changed the name of PmPointCloud to StampedPointCloud, because I thought it was more descriptive. I didn't, however, take away the aliases for PointMatcher classes present in using.h. Should I keep them?


Thank you.

Yoshua