### PR TITLE
Added new function for filtering PmStampedCloud without copy

### DIFF
--- a/pointmatcher_ros/include/pointmatcher_ros/PointMatcherFilterIface.h
+++ b/pointmatcher_ros/include/pointmatcher_ros/PointMatcherFilterIface.h
@@ -20,6 +20,8 @@ class PointMatcherFilterIface {
 
   PointMatcher<float>::DataPoints process(const PointMatcher<float>::DataPoints& input);
 
+  void processInPlace(PointMatcher<float>::DataPoints& input);
+
  private:
   std::string dataType_;
   PointMatcher<float>::DataPointsFilters filters_;

--- a/pointmatcher_ros/src/PointMatcherFilterIface.cpp
+++ b/pointmatcher_ros/src/PointMatcherFilterIface.cpp
@@ -18,16 +18,22 @@ bool PointMatcherFilterIface::readPipelineFile(const std::string& fileName) {
 }
 
 PointMatcher<float>::DataPoints PointMatcherFilterIface::process(const PointMatcher<float>::DataPoints& input) {
+  // Copy input point cloud.
   auto localInput = input;
 
+  // Apply filters to point cloud.
+  processInPlace(localInput);
+
+  return localInput;
+}
+
+void PointMatcherFilterIface::processInPlace(PointMatcher<float>::DataPoints& input) {
   try {
-    filters_.apply(localInput);
+    filters_.apply(input);
   } catch (const std::runtime_error& e) {
     ROS_WARN_STREAM("PointMatcherFilterIface: Caught exception: " << e.what());
     ROS_WARN_STREAM("PointMatcherFilterIface: Point cloud unchanged");
   }
-
-  return localInput;
 }
 
 }  // namespace PointMatcher_ros


### PR DESCRIPTION
I introduced a new function for applying point cloud filters without copying the point cloud contents. This can save 1-2ms when processing large point clouds.