### PR TITLE
Fix compiler warnings

### DIFF
--- a/pointmatcher_ros/include/pointmatcher_ros/PmTf.h
+++ b/pointmatcher_ros/include/pointmatcher_ros/PmTf.h
@@ -10,7 +10,10 @@
 #include <geometry_msgs/TransformStamped.h>
 
 // tf
+#pragma GCC diagnostic push // Get rid of compiler warnings we can't fix.
+#pragma GCC diagnostic ignored "-Wpedantic"
 #include <tf/tf.h>
+#pragma GCC diagnostic pop // Back to normal warning handling.
 
 // pointmatcher_ros
 #include "pointmatcher_ros/usings.h"

--- a/pointmatcher_ros/include/pointmatcher_ros/StampedPointCloud.h
+++ b/pointmatcher_ros/include/pointmatcher_ros/StampedPointCloud.h
@@ -10,7 +10,10 @@
 #include <pointmatcher_ros/point_cloud.h>
 
 // pcl
+#pragma GCC diagnostic push // Get rid of compiler warnings we can't fix.
+#pragma GCC diagnostic ignored "-Wpedantic"
 #include <pcl/io/ply_io.h>
+#pragma GCC diagnostic pop // Back to normal warning handling.
 
 // pcl conversions
 #include <pcl_conversions/pcl_conversions.h>

--- a/pointmatcher_ros/include/pointmatcher_ros/helper_functions.h
+++ b/pointmatcher_ros/include/pointmatcher_ros/helper_functions.h
@@ -9,7 +9,10 @@
 #include <geometry_msgs/TransformStamped.h>
 
 // tf
+#pragma GCC diagnostic push // Get rid of compiler warnings we can't fix.
+#pragma GCC diagnostic ignored "-Wpedantic"
 #include <tf/tf.h>
+#pragma GCC diagnostic pop // Back to normal warning handling.
 
 // tf conversions
 #include <tf_conversions/tf_eigen.h>

--- a/pointmatcher_ros/src/point_cloud.cpp
+++ b/pointmatcher_ros/src/point_cloud.cpp
@@ -6,7 +6,10 @@
 #include "boost/algorithm/string.hpp"
 //#include <boost/algorithm/string/predicate.hpp>
 //#include <boost/algorithm/string/erase.hpp>
+#pragma GCC diagnostic push // Get rid of compiler warnings we can't fix.
+#pragma GCC diagnostic ignored "-Wpedantic"
 #include "tf/transform_listener.h"
+#pragma GCC diagnostic pop // Back to normal warning handling.
 #include <vector>
 #include <memory>
 

--- a/pointmatcher_ros/src/transform.cpp
+++ b/pointmatcher_ros/src/transform.cpp
@@ -1,6 +1,9 @@
 #include "pointmatcher_ros/transform.h"
+#pragma GCC diagnostic push // Get rid of compiler warnings we can't fix.
+#pragma GCC diagnostic ignored "-Wpedantic"
 #include "tf/transform_listener.h"
 #include "tf/transform_datatypes.h"
+#pragma GCC diagnostic pop // Back to normal warning handling.
 #include "tf_conversions/tf_eigen.h"
 #include "eigen_conversions/eigen_msg.h"
 #include "ros/ros.h"


### PR DESCRIPTION
Disabled compiler warnings for certain ros headers, which are out of our control, to prevent flooding of the terminal when building.