### PR TITLE
[pointmatcher_ros] Use auto for instantiating filter.

### DIFF
--- a/pointmatcher_ros/src/StampedPointCloud.cpp
+++ b/pointmatcher_ros/src/StampedPointCloud.cpp
@@ -171,14 +171,14 @@ bool StampedPointCloud::filterByDistance(const float distanceThreshold, const bo
 
 bool StampedPointCloud::filterByBoundingBox(const float xMin, const float xMax, const float yMin, const float yMax, const float zMin,
                                             const float zMax, const bool keepInside) {
-  std::shared_ptr<PmPointCloudFilter> boundingBoxFilter = Pm::get().DataPointsFilterRegistrar.create(
-      "BoundingBoxDataPointsFilter", {{"xMin", PointMatcherSupport::toParam(xMin)},
-                                      {"xMax", PointMatcherSupport::toParam(xMax)},
-                                      {"yMin", PointMatcherSupport::toParam(yMin)},
-                                      {"yMax", PointMatcherSupport::toParam(yMax)},
-                                      {"zMin", PointMatcherSupport::toParam(zMin)},
-                                      {"zMax", PointMatcherSupport::toParam(zMax)},
-                                      {"removeInside", PointMatcherSupport::toParam(!keepInside)}});
+  auto boundingBoxFilter = Pm::get().DataPointsFilterRegistrar.create("BoundingBoxDataPointsFilter",
+                                                                      {{"xMin", PointMatcherSupport::toParam(xMin)},
+                                                                       {"xMax", PointMatcherSupport::toParam(xMax)},
+                                                                       {"yMin", PointMatcherSupport::toParam(yMin)},
+                                                                       {"yMax", PointMatcherSupport::toParam(yMax)},
+                                                                       {"zMin", PointMatcherSupport::toParam(zMin)},
+                                                                       {"zMax", PointMatcherSupport::toParam(zMax)},
+                                                                       {"removeInside", PointMatcherSupport::toParam(!keepInside)}});
   const bool success = filter(*boundingBoxFilter);
   return success;
 }


### PR DESCRIPTION
This fixes https://ci.leggedrobotics.com/blue/rest/organizations/jenkins/pipelines/bitbucket_leggedrobotics/pipelines/depth_sensor_calibration/branches/master/runs/285/nodes/13/steps/31/log/?start=0